### PR TITLE
72 | 3 lane configurations

### DIFF
--- a/BeatmapEdit.py
+++ b/BeatmapEdit.py
@@ -124,7 +124,7 @@ def set_lane(beat):
     if lane_input is None:
         return set_lane(beat)
     else:
-        return lane_input - 1
+        return lane_input
 
 
 # set the note type.

--- a/LaneArt.py
+++ b/LaneArt.py
@@ -77,6 +77,123 @@ TWO_LANES_LEFT_RIGHT = [
     ["None", "None", "None", "TwoLaneLR_0", "TwoLaneLR_1"])
 ]
 
+THREE_LANES_RIGHT_LEFT = [
+  ("\t╔═══════════════════╗\n" +
+   "\t║  1 ←---           ║\n" +
+   "\t║  2 ←---           ║\n" +
+   "\t║  3 ←---           ║\n" +
+   "\t║  x ----           ║\n" +
+   "\t║  x ----           ║\n" +
+   "\t╚═══════════════════╝",
+   ["ThreeLaneRL_0", "ThreeLaneRL_1", "ThreeLaneRL_2", "None", "None"]),
+  ("\t╔═══════════════════╗\n" +
+   "\t║  x ----           ║\n" +
+   "\t║  1 ←---           ║\n" +
+   "\t║  2 ←---           ║\n" +
+   "\t║  3 ←---           ║\n" +
+   "\t║  x ----           ║\n" +
+   "\t╚═══════════════════╝",
+   ["None", "ThreeLaneRL_0", "ThreeLaneRL_1", "ThreeLaneRL_2", "None"]),
+  ("\t╔═══════════════════╗\n" +
+   "\t║  x ----           ║\n" +
+   "\t║  x ----           ║\n" +
+   "\t║  1 ←---           ║\n" +
+   "\t║  2 ←---           ║\n" +
+   "\t║  3 ←---           ║\n" +
+   "\t╚═══════════════════╝",
+   ["None", "None", "ThreeLaneRL_0", "ThreeLaneRL_1", "ThreeLaneRL_2"])
+]
+
+THREE_LANES_LEFT_RIGHT = [
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║           ---→ 1  ║\n" +
+    "\t║           ---→ 2  ║\n" +
+    "\t║           ---→ 3  ║\n" +
+    "\t║           ---- x  ║\n" +
+    "\t║           ---- x  ║\n" +
+    "\t╚═══════════════════╝",
+    ["ThreeLaneLR_0", "ThreeLaneLR_1", "ThreeLaneLR_2", "None", "None"]),
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║           ---- x  ║\n" +
+    "\t║           ---→ 1  ║\n" +
+    "\t║           ---→ 2  ║\n" +
+    "\t║           ---→ 3  ║\n" +
+    "\t║           ---- x  ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "ThreeLaneLR_0", "ThreeLaneLR_1", "ThreeLaneLR_2", "None"]),
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║           ---- x  ║\n" +
+    "\t║           ---- x  ║\n" +
+    "\t║           ---→ 1  ║\n" +
+    "\t║           ---→ 2  ║\n" +
+    "\t║           ---→ 3  ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "None", "ThreeLaneLR_0", "ThreeLaneLR_1", "ThreeLaneLR_2"])
+]
+
+THREE_LANES_TOP_BOTTOM = [
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║                   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   ↓  ↓  ↓  |  |   ║\n" +
+    "\t║   1  2  3  x  x   ║\n" +
+    "\t╚═══════════════════╝",
+    ["ThreeLaneTB_0", "ThreeLaneTB_1", "ThreeLaneTB_2", "None", "None"]),
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║                   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  ↓  ↓  ↓  |   ║\n" +
+    "\t║   x  1  2  3  x   ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "ThreeLaneTB_0", "ThreeLaneTB_1", "ThreeLaneTB_2", "None"]),
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║                   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  ↓  ↓  ↓   ║\n" +
+    "\t║   x  x  1  2  3   ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "None", "ThreeLaneTB_0", "ThreeLaneTB_1", "ThreeLaneTB_2"])
+]
+
+THREE_LANES_BOTTOM_TOP = [
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║   1  2  3  x  x   ║\n" +
+    "\t║   ↑  ↑  ↑  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║                   ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "ThreeLaneBT_0", "ThreeLaneBT_1", "ThreeLaneBT_2", "None"]),
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║   x  1  2  3  x   ║\n" +
+    "\t║   |  ↑  ↑  ↑  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║                   ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "ThreeLaneBT_0", "ThreeLaneBT_1", "ThreeLaneBT_2", "None"]),
+  (
+    "\t╔═══════════════════╗\n" +
+    "\t║   x  x  1  2  3   ║\n" +
+    "\t║   |  |  ↑  ↑  ↑   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║   |  |  |  |  |   ║\n" +
+    "\t║                   ║\n" +
+    "\t╚═══════════════════╝",
+    ["None", "None", "ThreeLaneBT_0", "ThreeLaneBT_1", "ThreeLaneBT_2"])
+]
+
 FOUR_LANES_TOP_BOTTOM = [
   (
     "\t╔═══════════════════╗\n" +

--- a/README.md
+++ b/README.md
@@ -146,6 +146,48 @@ The names "left to right" or "top to bottom" indicate the direction in which the
 ╚═══════════════════╝
 ```
 
+#### Three Lanes
+* Three lanes left to right
+```
+╔═══════════════════╗
+║           ---→ 1  ║
+║           ---→ 2  ║
+║           ---→ 3  ║
+║           ---- x  ║
+║           ---- x  ║
+╚═══════════════════╝
+```
+* Three lanes right to left
+```
+╔═══════════════════╗
+║  1 ←---           ║
+║  2 ←---           ║
+║  3 ←---           ║
+║  x ----           ║
+║  x ----           ║
+╚═══════════════════╝
+```
+* Three lanes top to bottom
+```
+╔═══════════════════╗
+║                   ║
+║   |  |  |  |  |   ║
+║   |  |  |  |  |   ║
+║   |  ↓  ↓  ↓  |   ║
+║   x  1  2  3  x   ║
+╚═══════════════════╝
+```
+* Three lanes bottom to top
+```
+╔═══════════════════╗
+║   x  1  2  3  x   ║
+║   |  ↑  ↑  ↑  |   ║
+║   |  |  |  |  |   ║
+║   |  |  |  |  |   ║
+║                   ║
+╚═══════════════════╝
+```
+
 #### Four Lanes
 * Four lanes top to bottom
 ```
@@ -282,7 +324,17 @@ This is a single note like the tap note, but is visually distinguishable. It wil
 Please report any bugs or address any questions, comments, concerns, or suggestions to `projectradiance@kunehostudios.com` and include `Devtool` in the subject.
 
 ## Change Log
-### Version 0.1.1 (Latest)
+
+### Version 0.1.2 (Latest)
+##### [Lane Configurations and Variations]
+<p>&plus; Three Lanes</p>
+
+* Three lanes left to right
+* Three lanes right to left
+* Three lanes top to bottom
+* Three lanes bottom to top
+
+### Version 0.1.1 
 [Other]
 <br>
 &plus; Added a line to the <songName>Data.json which contains the path of the test audio file for the song

--- a/Util.py
+++ b/Util.py
@@ -33,7 +33,12 @@ two_lane_change_types_dict = {
     "Two Lanes Right to Left": LaneArt.TWO_LANES_RIGHT_LEFT,
 }
 
-three_lane_change_types_dict = {}
+three_lane_change_types_dict = {
+    "Three Lanes Top to Bottom": LaneArt.THREE_LANES_TOP_BOTTOM,
+    "Three Lanes Bottom to Top": LaneArt.THREE_LANES_BOTTOM_TOP,
+    "Three Lanes Left to Right": LaneArt.THREE_LANES_LEFT_RIGHT,
+    "Three Lanes Right to Left": LaneArt.THREE_LANES_RIGHT_LEFT
+}
 
 four_lane_change_types_dict = {
     "Four Lanes Top to Bottom": LaneArt.FOUR_LANES_TOP_BOTTOM,
@@ -55,7 +60,7 @@ five_lane_change_types_dict = {
 lane_change_types_dict = {
     # 1: ("One Lane", one_lane_change_types_dict),
     2: ("Two Lanes", two_lane_change_types_dict),
-    # 3: ("Three Lanes", three_lane_change_types_dict),
+    3: ("Three Lanes", three_lane_change_types_dict),
     4: ("Four Lanes", four_lane_change_types_dict),
     5: ("Five Lanes", five_lane_change_types_dict)
 }


### PR DESCRIPTION
### Summary
- Adding `Three Lanes Right to Left` (and 3 variations), `Three Lanes Left to Right` (and 3 variations), `Three Lanes Top to Bottom` (and 3 variations), and `Three Lanes Bottom to Top` (and 3 variations) to `LaneArt`
- `three_lane_change_types_dict` added to `Util` to hold the lane arts
- `lane_change_types_dict` now includes three lane configurations which makes them available for selection
- README and changelog updated to include 3 lane inclusion

### Testing
- [x] Created new beatmap and ensured that three lane configurations were present and selectable on initial configuration
- [x] Updated an existing beatmap and after using a `LaneChange` note that the three lane options were presented and selectable
- [x] After adding a note in a three lane configuration, the last note report correctly displays the three lanes

Closes #72 